### PR TITLE
Merge testing and dehydration check with "Add Data" view

### DIFF
--- a/Feedbridge.xcodeproj/project.pbxproj
+++ b/Feedbridge.xcodeproj/project.pbxproj
@@ -692,7 +692,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = Y6WUS7R97A;
+				DEVELOPMENT_TEAM = 8H2BH67V84;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Feedbridge/Supporting Files/Info.plist";
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cs342.2025.feedbridge;
+				PRODUCT_BUNDLE_IDENTIFIER = feedbridge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -896,7 +896,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = Y6WUS7R97A;
+				DEVELOPMENT_TEAM = 8H2BH67V84;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Feedbridge/Supporting Files/Info.plist";
@@ -919,7 +919,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cs342.2025.feedbridge;
+				PRODUCT_BUNDLE_IDENTIFIER = feedbridge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -938,12 +938,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Feedbridge/Supporting Files/Feedbridge.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 637867499T;
+				DEVELOPMENT_TEAM = 8H2BH67V84;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Feedbridge/Supporting Files/Info.plist";
@@ -966,10 +964,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cs342.2025.feedbridge;
+				PRODUCT_BUNDLE_IDENTIFIER = feedbridge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "CS342 2025 Feedbridge";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Feedbridge/FeedbridgeStandard.swift
+++ b/Feedbridge/FeedbridgeStandard.swift
@@ -133,4 +133,22 @@ actor FeedbridgeStandard: Standard,
             await logger.error("Could not store consent form: \(error)")
         }
     }
+    
+//    @MainActor
+//    func addDehydrationCheck(_ check: DehydrationCheck, toBabyWithId babyId: String) async throws {
+//        guard let userId = Auth.auth().currentUser?.uid else {
+//            await logger.error("Could not get current user id")
+//            return
+//        }
+//
+//        let fireStore = Firestore.firestore()
+//        let checksCollection = fireStore
+//            .collection("users")
+//            .document(userId)
+//            .collection("babies")
+//            .document(babyId)
+//            .collection("dehydrationChecks")
+//
+//        try await checksCollection.document().setData(from: check)
+//    }
 }

--- a/Feedbridge/Supporting Files/Feedbridge.entitlements
+++ b/Feedbridge/Supporting Files/Feedbridge.entitlements
@@ -1,18 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
-	<key>com.apple.developer.healthkit</key>
-	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array/>
-	<key>com.apple.developer.healthkit.background-delivery</key>
-	<true/>
-	<key>com.apple.developer.usernotifications.time-sensitive</key>
-	<true/>
-</dict>
+<dict/>
 </plist>

--- a/Feedbridge/Views/DehydrationView.swift
+++ b/Feedbridge/Views/DehydrationView.swift
@@ -2,9 +2,87 @@
 //  DehydrationView.swift
 //  Feedbridge
 //
-//  Created by Shamit Surana on 2/8/25.
+//  Created by Shreya D'Souza on 2/8/25.
 //
 // SPDX-FileCopyrightText: 2025 Stanford University
 //
 // SPDX-License-Identifier: MIT
 //
+
+import FirebaseFirestore
+import SwiftUI
+
+struct AddDehydrationCheckView: View {
+    @Environment(FeedbridgeStandard.self) private var standard
+    @Environment(\.dismiss) private var dismiss
+    
+    let babyId: String
+    
+    @State private var poorSkinElasticity = false
+    @State private var dryMucousMembranes = false
+    @State private var date = Date()
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    DatePicker("Date & Time", selection: $date)
+                }
+        
+                
+            if let error = errorMessage {
+                    Section {
+                        Text(error)
+                            .foregroundColor(.red)
+                    }
+                }
+            }
+            .navigationTitle("Add Dehydration Check")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task {
+                            await saveDehydrationCheck()
+                        }
+                    }
+                    .disabled(isLoading)
+                }
+            }
+        }
+    }
+    
+    private func saveDehydrationCheck() async {
+        isLoading = true
+        errorMessage = nil
+        
+//        let check = DehydrationCheck(
+//            id: nil,
+//            dateTime: date,
+//            poorSkinElasticity: poorSkinElasticity,
+//            dryMucousMembranes: dryMucousMembranes
+//        )
+//        
+//        do {
+//            try await standard.addDehydrationCheck(check, toBabyWithId: babyId)
+//            dismiss()
+//        } catch {
+//            errorMessage = error.localizedDescription
+//        }
+        
+        isLoading = false
+    }
+}
+
+#Preview {
+    AddDehydrationCheckView(babyId: "preview")
+        .previewWith(standard: FeedbridgeStandard()) {
+        }
+}

--- a/FeedbridgeUITests/AddDataViewTests.swift
+++ b/FeedbridgeUITests/AddDataViewTests.swift
@@ -1,0 +1,57 @@
+//
+//  AddDataViewTests.swift
+//  Feedbridge
+//
+//  Created by Shreya D'Souza on 2/11/25.
+//
+
+import XCTest
+
+class AddDataAViewUITests: XCTestCase {
+    @MainActor
+    override func setUp() async throws {
+        continueAfterFailure = false
+        
+        let app = XCUIApplication()
+        app.launchArguments = ["--setupTestAccount", "--skipOnboarding"]
+        app.deleteAndLaunch(withSpringboardAppName: "Feedbridge")
+    }
+    
+    /// Tests if all data entry buttons exist in the view
+    @MainActor
+    func testDataEntryButtonsExist() {
+        let app = XCUIApplication()
+        let feedEntryButton = app.buttons["Feed Entry"]
+        let wetDiaperButton = app.buttons["Wet Diaper Entry"]
+        let stoolEntryButton = app.buttons["Stool Entry"]
+        let dehydrationCheckButton = app.buttons["Dehydration Check"]
+        let weightEntryButton = app.buttons["Weight Entry"]
+        
+        XCTAssertTrue(feedEntryButton.exists, "Feed Entry button should exist")
+        XCTAssertTrue(wetDiaperButton.exists, "Wet Diaper Entry button should exist")
+        XCTAssertTrue(stoolEntryButton.exists, "Stool Entry button should exist")
+        XCTAssertTrue(dehydrationCheckButton.exists, "Dehydration Check button should exist")
+        XCTAssertTrue(weightEntryButton.exists, "Weight Entry button should exist")
+    }
+    
+    /// Tests tapping each button
+    @MainActor
+    func testTapDataEntryButtons() {
+        let buttons = ["Feed Entry", "Wet Diaper Entry", "Stool Entry", "Dehydration Check", "Weight Entry"]
+        
+        for buttonLabel in buttons {
+            let app = XCUIApplication()
+            let button = app.buttons[buttonLabel]
+            XCTAssertTrue(button.exists, "\(buttonLabel) button should exist")
+            button.tap()
+            // Assert any expected behavior after tapping
+        }
+    }
+    
+    /// Tests if the navigation title is correct
+    @MainActor
+    func testNavigationTitle() {
+        let app = XCUIApplication()
+        XCTAssertTrue(app.staticTexts["Add Data"].exists, "Navigation title should be 'Add Data'")
+    }
+}


### PR DESCRIPTION
This pull request merges initial testing for the "Add Data" view, which tests the setup and presence of buttons to add data entries for a particular baby. It also adds a beginning implementation of the "Dehydration Check" view, without the Firebase connection. 