### PR TITLE
Added UI tests for AddEntryView

### DIFF
--- a/Feedbridge.xcodeproj/project.pbxproj
+++ b/Feedbridge.xcodeproj/project.pbxproj
@@ -722,7 +722,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = Y6WUS7R97A;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Feedbridge/Supporting Files/Info.plist";
@@ -926,52 +926,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = Y6WUS7R97A;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = "Feedbridge/Supporting Files/Info.plist";
-				INFOPLIST_KEY_NSCameraUsageDescription = "This message should never appear. Please adjust this when you start using camera information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
-				INFOPLIST_KEY_NSHealthShareUsageDescription = "The Feedbridge uses the step count to demonstrate Spezi's integration with HealthKit.";
-				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "The Feedbridge uses the step count to demonstrate Spezi's integration with HealthKit.";
-				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "This message should never appear. Please adjust this when you start using location information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "This message should never appear. Please adjust this when you start using location information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This message should never appear. Please adjust this when you start using microphone information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
-				INFOPLIST_KEY_NSMotionUsageDescription = "This message should never appear. Please adjust this when you start using motion information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "This message should never appear. Please adjust this when you start using speecg information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
-				INFOPLIST_KEY_UIFeedbridgelicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIFeedbridgelicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = shamit.edu.stanford.cs342.2025.feedbridge;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				"SWIFT_ELicenseRef-Feedbridge_LOC_STRINGS" = YES;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		653A257328338800005D4D48 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = "Feedbridge/Supporting Files/Feedbridge.entitlements";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = Y6WUS7R97A;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Feedbridge/Supporting Files/Info.plist";
@@ -997,6 +952,54 @@
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cs342.2025.feedbridge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				"SWIFT_ELicenseRef-Feedbridge_LOC_STRINGS" = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		653A257328338800005D4D48 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Feedbridge/Supporting Files/Feedbridge.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 637867499T;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Feedbridge/Supporting Files/Info.plist";
+				INFOPLIST_KEY_NSCameraUsageDescription = "This message should never appear. Please adjust this when you start using camera information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "The Feedbridge uses the step count to demonstrate Spezi's integration with HealthKit.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "The Feedbridge uses the step count to demonstrate Spezi's integration with HealthKit.";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "This message should never appear. Please adjust this when you start using location information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "This message should never appear. Please adjust this when you start using location information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This message should never appear. Please adjust this when you start using microphone information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
+				INFOPLIST_KEY_NSMotionUsageDescription = "This message should never appear. Please adjust this when you start using motion information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "This message should never appear. Please adjust this when you start using speecg information. We have to put this in here as ResearchKit has the possibility to use it and not putting it here returns an error on AppStore Connect.";
+				INFOPLIST_KEY_UIFeedbridgelicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIFeedbridgelicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.cs342.2025.feedbridge;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "CS342 2025 Feedbridge";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Feedbridge.xcodeproj/project.pbxproj
+++ b/Feedbridge.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		56E708352BB06B7100B08F0A /* SpeziLicense in Frameworks */ = {isa = PBXBuildFile; productRef = 56E708342BB06B7100B08F0A /* SpeziLicense */; };
 		56E7083B2BB06F6F00B08F0A /* SwiftPackageList in Frameworks */ = {isa = PBXBuildFile; productRef = 56E7083A2BB06F6F00B08F0A /* SwiftPackageList */; };
 		5B2B9CB92D52F9BF0047A55C /* AddBabyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2B9CB82D52F9BF0047A55C /* AddBabyView.swift */; };
+		5B8425C82D829FC1009B00BC /* AddEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8425C72D829FC1009B00BC /* AddEntryTests.swift */; };
 		5BB4CE322D5B183200DA4CF7 /* AddSingleBabyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB4CE312D5B183200DA4CF7 /* AddSingleBabyView.swift */; };
 		5BC74CDA2D6E19320059AA19 /* AddEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC74CD92D6E19320059AA19 /* AddEntryView.swift */; };
 		5BD66F352D7EC73D0043D295 /* TestModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD66F342D7EC73B0043D295 /* TestModels.swift */; };
@@ -125,6 +126,7 @@
 		53F30C272D7FBB670077FD21 /* AddDataViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDataViewTests.swift; sourceTree = "<group>"; };
 		5680DD3D2AB8CD84004E6D4A /* ContributionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributionsTest.swift; sourceTree = "<group>"; };
 		5B2B9CB82D52F9BF0047A55C /* AddBabyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBabyView.swift; sourceTree = "<group>"; };
+		5B8425C72D829FC1009B00BC /* AddEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEntryTests.swift; sourceTree = "<group>"; };
 		5BB4CE312D5B183200DA4CF7 /* AddSingleBabyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSingleBabyView.swift; sourceTree = "<group>"; };
 		5BC74CD92D6E19320059AA19 /* AddEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEntryView.swift; sourceTree = "<group>"; };
 		5BD66F342D7EC73B0043D295 /* TestModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModels.swift; sourceTree = "<group>"; };
@@ -340,6 +342,7 @@
 		653A256A28338800005D4D48 /* FeedbridgeUITests */ = {
 			isa = PBXGroup;
 			children = (
+				5B8425C72D829FC1009B00BC /* AddEntryTests.swift */,
 				35B62F792D8257E80096904E /* AddBabyTests.swift */,
 				53F30C272D7FBB670077FD21 /* AddDataViewTests.swift */,
 				2F4E237D2989A2FE0013F3D9 /* OnboardingTests.swift */,
@@ -611,6 +614,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5680DD3E2AB8CD84004E6D4A /* ContributionsTest.swift in Sources */,
+				5B8425C82D829FC1009B00BC /* AddEntryTests.swift in Sources */,
 				2F4E23872989DB360013F3D9 /* ContactsTests.swift in Sources */,
 				53F30C282D7FBB670077FD21 /* AddDataViewTests.swift in Sources */,
 				2F4E237E2989A2FE0013F3D9 /* OnboardingTests.swift in Sources */,

--- a/Feedbridge/FeedbridgeStandard.swift
+++ b/Feedbridge/FeedbridgeStandard.swift
@@ -75,7 +75,7 @@ actor FeedbridgeStandard: Standard,
                 logger.error("Could not delete user document: \(error)")
             }
         }
-        if case let .disassociatingAccount(accountId) = event {
+        if case let .disassociatingAccount(_) = event {
             print("logout")
             UserDefaults.standard.selectedBabyId = nil
         }

--- a/Feedbridge/HomeView.swift
+++ b/Feedbridge/HomeView.swift
@@ -29,7 +29,7 @@ struct HomeView: View {
             Tab("Dashboard", systemImage: "house", value: .dashboard) {
                 DashboardView(viewModel: viewModel, presentingAccount: $presentingAccount)
             }
-            Tab("Add Entries", systemImage: "plus", value: .addEntries) {
+            Tab("Add Entry", systemImage: "plus", value: .addEntries) {
                 AddEntryView(viewModel: viewModel)
             }
             Tab("Settings", systemImage: "gear", value: .debug) {

--- a/Feedbridge/Resources/Localizable.xcstrings
+++ b/Feedbridge/Resources/Localizable.xcstrings
@@ -87,9 +87,6 @@
     "Add Baby" : {
 
     },
-    "Add Entries" : {
-
-    },
     "Add Entry" : {
 
     },

--- a/Feedbridge/Views/Dashboard/AlertView.swift
+++ b/Feedbridge/Views/Dashboard/AlertView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 struct AlertView: View {
     let baby: Baby  // Baby object containing health-related entries
-    
+
     // Optional viewModel for real-time data
     var viewModel: DashboardViewModel?
 
@@ -29,7 +29,7 @@ struct AlertView: View {
     private var recentAlerts: [String] {
         let oneWeekAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
         var alerts: Set<String> = [] // Using Set to store unique alerts
-        
+
         // Check for dehydration risk from wet diaper entries
         if currentBaby.wetDiaperEntries.wetDiaperEntries.contains(where: { $0.dateTime >= oneWeekAgo && $0.dehydrationAlert }) {
             alerts.insert("Pink or red-tinged void detected.")

--- a/Feedbridge/Views/Dashboard/DehydrationCharts.swift
+++ b/Feedbridge/Views/Dashboard/DehydrationCharts.swift
@@ -25,7 +25,7 @@ struct AlertGridView: View {
         formatter.timeStyle = .none
         return formatter
     }()
-    
+
     var entries: [DehydrationCheck]
 
     private var pastWeekAlerts: [AlertData] {
@@ -92,7 +92,7 @@ struct DehydrationSummaryView: View {
         }
         return entries
     }
-    
+
     private var lastEntry: DehydrationCheck? {
         currentEntries.max(by: { $0.dateTime < $1.dateTime })
     }

--- a/FeedbridgeUITests/AddBabyTests.swift
+++ b/FeedbridgeUITests/AddBabyTests.swift
@@ -33,7 +33,7 @@ class AddBabyTests: XCTestCase {
         app.buttons["Settings"].tap()
 
         let deleteButton = app.buttons["Delete Baby, Delete Baby"]
-        
+
         // If the delete button exists, repeatedly tap it to remove all babies
         while deleteButton.waitForExistence(timeout: 2) {
             deleteButton.tap()
@@ -45,11 +45,11 @@ class AddBabyTests: XCTestCase {
     func testAddBaby() {
         let app = XCUIApplication()
         app.buttons["Settings"].tap()
-        
+
         // Verify initial state: No baby should be selected
         XCTAssertTrue(app.staticTexts["Select Baby"].exists, "Select baby dropdown should be visible")
         XCTAssertTrue(app.staticTexts["No baby selected"].exists, "No babies should exist")
-        
+
         // Open the dropdown menu and select "Add New Baby"
         let dropdown = app.buttons["Baby icon, Select Baby, Menu dropdown"]
         dropdown.tap()
@@ -74,13 +74,13 @@ class AddBabyTests: XCTestCase {
         datePickersQuery.tap()
         app.staticTexts["1"].tap()
         app.buttons["PopoverDismissRegion"].tap() // Close the date picker
-        
+
         // Ensure the Save button is enabled now that valid data is entered
         XCTAssertTrue(saveButton.isEnabled, "Save button should be enabled when valid data is entered")
 
         // Save the baby data
         saveButton.tap()
-        
+
         // Verify that the new baby is correctly added and displayed in the UI
         XCTAssertTrue(app.staticTexts["Benjamin"].exists, "Baby's name should be displayed")
         XCTAssertTrue(app.buttons["Baby icon, Benjamin, Menu dropdown"].exists, "Baby dropdown should show new baby")

--- a/FeedbridgeUITests/AddEntryTests.swift
+++ b/FeedbridgeUITests/AddEntryTests.swift
@@ -1,0 +1,449 @@
+//
+//  AddEntryTests.swift
+//  FeedbridgeUITests
+//
+//  Created by Calvin Xu on 3/12/25.
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+
+/// A test suite covering the AddEntryView in detail.
+@MainActor
+final class AddEntryTests: XCTestCase {
+    /// Sets up the test environment before each test case.
+    /// Ensures that there are no existing babies and launches the app with test configurations.
+    override func setUp() async throws {
+        continueAfterFailure = false
+
+        let app = XCUIApplication()
+        // These launch arguments and method calls are placeholders;
+        // adjust to match your actual test config or app lifecycle approach.
+        app.launchArguments = ["--setupTestAccount", "--skipOnboarding"]
+
+        // Example helper that can remove all babies so we can test the "No babies found" flow.
+        // If you have a different approach, adapt accordingly.
+        app.deleteAndLaunch(withSpringboardAppName: "Feedbridge")
+        deleteAllBabies(app)
+        createTestBaby(app)
+    }
+
+    // MARK: - Helpers
+
+    /// Deletes all babies using the UI delete button, ensuring a clean state before each test.
+    /// - Parameter app: The XCUIApplication instance.
+    private func deleteAllBabies(_ app: XCUIApplication) {
+        app.buttons["Settings"].tap()
+
+        let deleteButton = app.buttons["Delete Baby, Delete Baby"]
+
+        // If the delete button exists, repeatedly tap it to remove all babies
+        while deleteButton.waitForExistence(timeout: 2) {
+            deleteButton.tap()
+            app.buttons["Delete"].tap()
+        }
+    }
+
+    /// Optionally, if you need a baby in order to use AddEntryView, create it here.
+    /// In some tests we want to see "No babies found", so we won't call this for every test.
+    private func createTestBaby(_ app: XCUIApplication, name: String = "TestBaby") {
+        app.buttons["Settings"].tap()
+
+        let dropdown = app.buttons["Baby icon, Select Baby, Menu dropdown"]
+        dropdown.tap()
+
+        let addNewBaby = app.buttons["Add New Baby"]
+        XCTAssertTrue(addNewBaby.waitForExistence(timeout: 2), "Add New Baby button not found.")
+        addNewBaby.tap()
+
+        let nameField = app.textFields["Baby's Name"]
+        XCTAssertTrue(nameField.waitForExistence(timeout: 2), "Baby's Name field not found.")
+        nameField.tap()
+        nameField.typeText(name)
+
+        // Set a date in the past to satisfy any constraints
+        let datePickersQuery = app.datePickers.firstMatch
+        datePickersQuery.tap()
+        // Just pick day "1" to ensure valid date
+        app.staticTexts["1"].tap()
+        // Dismiss the date picker popover
+        app.buttons["PopoverDismissRegion"].tap()
+
+        let saveButton = app.buttons["Save"]
+        XCTAssertTrue(saveButton.isEnabled, "Save button should be enabled with valid baby data.")
+        saveButton.tap()
+
+        // Return to main or feed screen if needed
+        // app.buttons["Dashboard"].tap()
+    }
+
+    // MARK: - Tests
+
+    /// Tests the scenario where there are no babies in the system, so "No babies found" should appear in AddEntryView.
+    func testNoBabiesFoundFlow() throws {
+        let app = XCUIApplication()
+        app.launch()
+        deleteAllBabies(app)
+
+        // Navigate to AddEntryView if needed; for example:
+        // If you have a tab bar or a button that takes you there, adapt to your UI.
+        // Suppose we have a tab named "Add Entry" for direct testing:
+        app.buttons["Add Entry"].tap()
+
+        // Debug print for diagnosing element-finding issues
+        print("DEBUG: Current UI after tapping 'Add Entry':\n\(app.debugDescription)")
+
+        // Check that "No babies found" is displayed
+        XCTAssertTrue(app.staticTexts["No babies found"].exists, "Should show 'No babies found' message if there are no babies.")
+        XCTAssertTrue(app.staticTexts["Please add a baby in Settings before adding entries."].exists)
+    }
+
+    /// Tests adding a weight entry in kilograms.
+    func testAddWeightInKilograms() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        //        createTestBaby(app)
+
+        // Navigate to AddEntryView
+        app.buttons["Add Entry"].tap()
+
+        // Debug print
+        print("DEBUG: Current UI for 'AddEntryView':\n\(app.debugDescription)")
+
+        // Tap the "Weight" button
+        let weightButton = app.buttons["Weight"]
+        XCTAssertTrue(weightButton.waitForExistence(timeout: 2), "Weight button not found.")
+        weightButton.tap()
+
+        // Verify that the Kilograms text field is present
+        let kilogramsField = app.textFields["Kilograms"]
+        XCTAssertTrue(kilogramsField.waitForExistence(timeout: 2), "Kilograms text field not found after tapping Weight.")
+        // Confirm the unit toggle is on "Kilograms" by default or set it if needed
+        XCTAssertTrue(app.buttons["Kilograms"].isSelected, "Kilograms should be selected.")
+
+        // Enter a valid weight
+        kilogramsField.tap()
+        kilogramsField.typeText("3.5")
+
+        // Debug to ensure we typed the correct value
+        print("DEBUG: Entered weight in kg: \(kilogramsField.value ?? "")")
+
+        // Tap Confirm
+        let confirmButton = app.buttons["Confirm"]
+        XCTAssertTrue(confirmButton.isEnabled, "Confirm should be enabled with valid kg weight.")
+        confirmButton.tap()
+
+        // Verify success banner
+        let successBanner = app.staticTexts["Entry saved successfully!"]
+        XCTAssertTrue(successBanner.waitForExistence(timeout: 4), "Success banner goes away.")
+    }
+
+    /// Tests adding a weight entry in pounds and ounces.
+    func testAddWeightInPoundsOunces() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Create a baby
+        //        createTestBaby(app)
+
+        // Navigate to AddEntryView
+        app.buttons["Add Entry"].tap()
+
+        // Tap the "Weight" button
+        let weightButton = app.buttons["Weight"]
+        XCTAssertTrue(weightButton.waitForExistence(timeout: 2))
+        weightButton.tap()
+
+        // Switch the picker to "Pounds & Ounces"
+        app.buttons["Pounds & Ounces"].tap()
+
+        print("DEBUG: Current UI for 'AddEntryView':\n\(app.debugDescription)")
+
+        // Fill in pounds and ounces
+        let poundsField = app.textFields["Pounds"]
+        let ouncesField = app.textFields["Ounces"]
+        XCTAssertTrue(poundsField.waitForExistence(timeout: 2), "Pounds text field not found.")
+        XCTAssertTrue(ouncesField.waitForExistence(timeout: 2), "Ounces text field not found.")
+
+        poundsField.tap()
+        poundsField.typeText("7")
+        ouncesField.tap()
+        ouncesField.typeText("5.5")
+
+        print("DEBUG: Entered weight in lb/oz: \(poundsField.value ?? "") lb, \(ouncesField.value ?? "") oz")
+
+        // Tap Confirm
+        let confirmButton = app.buttons["Confirm"]
+        XCTAssertTrue(confirmButton.isEnabled, "Confirm should be enabled with valid lb/oz weight.")
+        confirmButton.tap()
+
+        // Verify success banner
+        let successBanner = app.staticTexts["Entry saved successfully!"]
+        XCTAssertTrue(successBanner.waitForExistence(timeout: 3))
+    }
+
+    /// Tests feeding entry with direct breastfeeding.
+    func testAddFeedingDirectBreastfeeding() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Create a baby
+        //        createTestBaby(app)
+
+        // Navigate to AddEntryView
+        app.buttons["Add Entry"].tap()
+
+        // Tap "Feed"
+        let feedingButton = app.buttons["Feed"]
+        XCTAssertTrue(feedingButton.waitForExistence(timeout: 2))
+        feedingButton.tap()
+
+        // Confirm the UI for direct breastfeeding
+        XCTAssertTrue(
+            app.buttons["Direct Breastfeeding"].isSelected,
+            "Should default to Direct Breastfeeding, unless your code picks otherwise."
+        )
+
+        // Enter a feed time
+        let feedTimeField = app.textFields["Feed time (minutes)"]
+        XCTAssertTrue(feedTimeField.exists, "Feed time text field should be present for direct breastfeeding.")
+        feedTimeField.tap()
+        feedTimeField.typeText("15")
+
+        print("DEBUG: Entered feed time: \(feedTimeField.value ?? "") minutes")
+
+        // Tap Confirm
+        let confirmButton = app.buttons["Confirm"]
+        XCTAssertTrue(confirmButton.isEnabled, "Confirm should be enabled with valid feed time.")
+        confirmButton.tap()
+
+        // Verify success
+        let successBanner = app.staticTexts["Entry saved successfully!"]
+        XCTAssertTrue(successBanner.waitForExistence(timeout: 3))
+    }
+
+    /// Tests feeding entry with a bottle (volume in mL, milk type).
+    func testAddFeedingBottle() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Create a baby
+        // createTestBaby(app)
+
+        // Navigate to AddEntryView
+        app.buttons["Add Entry"].tap()
+
+        // Tap "Feed"
+        let feedingButton = app.buttons["Feed"]
+        XCTAssertTrue(feedingButton.waitForExistence(timeout: 2))
+        feedingButton.tap()
+
+        // Switch to "Bottle"
+        app.buttons["Bottle"].tap()
+
+        // Enter bottle volume
+        let volumeField = app.textFields["Bottle volume (ml)"]
+        XCTAssertTrue(volumeField.waitForExistence(timeout: 2))
+        volumeField.tap()
+        volumeField.typeText("60")
+
+        print("DEBUG: Entered bottle volume: \(volumeField.value ?? "") ml")
+
+        // Pick milk type if you want to switch from default
+        app.buttons["Formula"].tap()
+
+        // Confirm
+        let confirmButton = app.buttons["Confirm"]
+        XCTAssertTrue(confirmButton.isEnabled)
+        confirmButton.tap()
+
+        // Success
+        let successBanner = app.staticTexts["Entry saved successfully!"]
+        XCTAssertTrue(successBanner.waitForExistence(timeout: 3))
+    }
+
+    /// Tests adding a wet diaper (void) entry.
+    func testAddWetDiaper() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Create baby
+        //        createTestBaby(app)
+
+        // Navigate to AddEntryView
+        app.buttons["Add Entry"].tap()
+
+        // Tap "Void"
+        let voidButton = app.buttons["Void"]
+        XCTAssertTrue(voidButton.waitForExistence(timeout: 2))
+        voidButton.tap()
+
+        // Pick volume
+        app.buttons["Medium"].tap()
+
+        // Pick color
+        app.buttons["Red"].tap()
+
+        print("DEBUG: Selected wet diaper volume = Medium, color = Red")
+
+        // Confirm
+        let confirmButton = app.buttons["Confirm"]
+        XCTAssertTrue(confirmButton.isEnabled)
+        confirmButton.tap()
+
+        // Success
+        let successBanner = app.staticTexts["Entry saved successfully!"]
+        XCTAssertTrue(successBanner.waitForExistence(timeout: 3))
+    }
+
+    /// Tests adding a stool entry.
+    func testAddStool() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Create baby
+        //        createTestBaby(app)
+
+        // Navigate to AddEntryView
+        app.buttons["Add Entry"].tap()
+
+        // Tap "Stool"
+        let stoolButton = app.buttons["Stool"]
+        XCTAssertTrue(stoolButton.waitForExistence(timeout: 2))
+        stoolButton.tap()
+
+        // Select volume
+        app.buttons["Heavy"].tap()
+
+        // Select color
+        app.buttons["Green"].tap()
+
+        print("DEBUG: Selected stool volume = Heavy, color = Green")
+
+        // Confirm
+        let confirmButton = app.buttons["Confirm"]
+        XCTAssertTrue(confirmButton.isEnabled)
+        confirmButton.tap()
+
+        // Success
+        let successBanner = app.staticTexts["Entry saved successfully!"]
+        XCTAssertTrue(successBanner.waitForExistence(timeout: 3))
+    }
+
+    /// Tests adding a dehydration entry (toggle fields).
+    func testAddDehydration() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Create baby
+        //        createTestBaby(app)
+
+        // Navigate to AddEntryView
+        app.buttons["Add Entry"].tap()
+
+        // Tap "Dehydration"
+        let dehydrationButton = app.buttons["Dehydration"]
+        XCTAssertTrue(dehydrationButton.waitForExistence(timeout: 2))
+        dehydrationButton.tap()
+
+        // Toggle poor skin elasticity
+        let poorSkinSwitch = app.switches["Poor Skin Elasticity"]
+        XCTAssertTrue(poorSkinSwitch.exists, "Poor Skin Elasticity toggle not found.")
+        poorSkinSwitch.tap()
+
+        // Toggle dry mucous membranes
+        let dryMucousSwitch = app.switches["Dry Mucous Membranes"]
+        XCTAssertTrue(dryMucousSwitch.exists, "Dry Mucous Membranes toggle not found.")
+        dryMucousSwitch.tap()
+
+        print("DEBUG: Dehydration toggles set on")
+
+        // Confirm
+        let confirmButton = app.buttons["Confirm"]
+        XCTAssertTrue(confirmButton.isEnabled)
+        confirmButton.tap()
+
+        // Success
+        let successBanner = app.staticTexts["Entry saved successfully!"]
+        XCTAssertTrue(successBanner.waitForExistence(timeout: 3))
+    }
+
+    /// Tests that invalid weight inputs show an error or keep the Confirm button disabled.
+    func testInvalidWeightEntry() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Create baby
+        //        createTestBaby(app)
+
+        // Go to Add Entry
+        app.buttons["Add Entry"].tap()
+
+        // Tap "Weight"
+        app.buttons["Weight"].tap()
+
+        // By default, let's assume it’s “Kilograms”. Leave it blank or enter invalid data.
+        let kgField = app.textFields["Kilograms"]
+        kgField.tap()
+        kgField.typeText("-1")  // Invalid negative value
+
+        print("DEBUG: Entered invalid kg weight: \(kgField.value ?? "")")
+
+        // Confirm button should either be disabled or show a local error message
+        let confirmButton = app.buttons["Confirm"]
+        XCTAssertTrue(
+            !confirmButton.isEnabled,
+            "Button not enabled"
+        )
+
+        // Tap confirm
+        confirmButton.tap()
+
+        // Because the code logic for weight says: if negative => formCheck returns an error => We expect to see a red error text.
+        let errorLabel = app.staticTexts["Invalid weight (kg) value."]
+        XCTAssertTrue(errorLabel.waitForExistence(timeout: 2), "Should show an error label for invalid weight input.")
+
+        // At this point, the entry won't be saved, so "Entry saved successfully!" should NOT appear
+        let successBanner = app.staticTexts["Entry saved successfully!"]
+        XCTAssertFalse(successBanner.exists, "Success banner should not appear with invalid input.")
+    }
+
+    /// Tests that invalid feeding input (zero or negative time or volume) is handled properly.
+    func testInvalidFeedingInput() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Create baby
+        //        createTestBaby(app)
+
+        // Go to Add Entry
+        app.buttons["Add Entry"].tap()
+
+        // Tap "Feed"
+        app.buttons["Feed"].tap()
+
+        // Direct breastfeeding is default
+        let minutesField = app.textFields["Feed time (minutes)"]
+        minutesField.tap()
+        minutesField.typeText("0") // Invalid
+
+        print("DEBUG: Entered invalid feed time: \(minutesField.value ?? "") minutes")
+
+        // The formCheck would return error for 0 => "Invalid feed time (minutes)."
+        let confirmButton = app.buttons["Confirm"]
+        XCTAssertTrue(!confirmButton.isEnabled, "Button should not be enabled")
+
+        confirmButton.tap()
+
+        // Wait for error
+        let errorLabel = app.staticTexts["Invalid feed time (minutes)."]
+        XCTAssertTrue(errorLabel.waitForExistence(timeout: 2), "Should show an error label for invalid feed time.")
+
+        let successBanner = app.staticTexts["Entry saved successfully!"]
+        XCTAssertFalse(successBanner.exists, "Success banner should not appear with invalid feeding data.")
+    }
+}


### PR DESCRIPTION
# Added UI tests for AddEntryView

## :gear: Release Notes 
* Added `AddEntryTests.swift`; coverage up to 62%

![image](https://github.com/user-attachments/assets/b312d619-ed21-4295-80f8-36ddfd569260)

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
